### PR TITLE
Add: tournaments.open_for_predictions

### DIFF
--- a/challonge/tournaments.py
+++ b/challonge/tournaments.py
@@ -67,6 +67,19 @@ def abort_check_in(tournament, **params):
         **params)
 
 
+def open_for_predictions(tournament, **params):
+    """Open predictions for a tournament
+
+    Sets the state of the tournament to start accepting predictions.
+    'prediction_method' must be set to 1 (exponential scoring) or 2 (linear scoring) to use this option.
+
+    """
+    return api.fetch_and_parse(
+        "POST",
+        "tournaments/%s/open_for_predictions" % tournament,
+        **params)
+
+
 def start(tournament, **params):
     """Start a tournament, opening up matches for score reporting.
 

--- a/tests.py
+++ b/tests.py
@@ -109,6 +109,16 @@ class TournamentsTestCase(unittest.TestCase):
 
         self.assertEqual(t['tournament_type'], "round robin")
 
+    def test_open(self):
+        challonge.tournaments.update(self.t['id'], prediction_method=1)
+        challonge.participants.create(self.t['id'], "#1")
+        challonge.participants.create(self.t['id'], "#2")
+
+        challonge.tournaments.open_for_predictions(self.t['id'])
+
+        t = challonge.tournaments.show(self.t['id'])
+        self.assertEqual(t['state'], "accepting_predictions")
+
     def test_start(self):
         # we have to add participants in order to start()
         self.assertRaises(


### PR DESCRIPTION
This adds an `open_for_predictions` method to `tournaments`.

See: https://api.challonge.com/v1/documents/tournaments/open_for_predictions#