### PR TITLE
Ignore pylintrc file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,9 @@ target/
 # pyenv
 .python-version
 
+# pylint
+.pylintrc
+
 # celery beat schedule file
 celerybeat-schedule
 


### PR DESCRIPTION
We should ignore the pylintrc file for those with different pylint configurastions.